### PR TITLE
chore: update justfile build-tree order

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -48,10 +48,10 @@ build-tree:
     just build composefs-rs
     just build dracut
 
+    just build py3-pefile
     just build systemd
     just build kernel
     just build kernel-initramfs
-    just build py3-pefile
     just build kernel-uki
 
 renovate:


### PR DESCRIPTION
`systemd-ukify` depends on `py3-pefile`, so move the build to before then.