### PR TITLE
Fix wolfi building on fresh pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages/
 .cache/
 melange.rsa*
 output/
+bootable.img

--- a/Containerfile
+++ b/Containerfile
@@ -1,17 +1,8 @@
 FROM scratch AS ctx
 
 COPY ./packages /packages
-COPY ./files /files
 
 FROM cgr.dev/chainguard/wolfi-base AS builder
-
-# This allows using this container to make a deployment.
-RUN ln -s sysroot/ostree /ostree
-
-# We need the ostree hook.
-RUN install -d /mnt/etc
-COPY --from=ctx /files/ostree.conf /mnt/etc/dracut.conf.d/
-COPY --from=ctx /files/wolfi-defaultfs.conf /mnt/usr/lib/bootc/install/
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx apk add -X https://packages.wolfi.dev/os --allow-untrusted -U --initdb -p /mnt \
     /ctx/packages/$(arch)/ostree*.apk \
@@ -30,7 +21,8 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx apk add -X https://packages.
     strace \
     libselinux \
     findmnt \
-    podman \
+    # TODO: Uncomment once upstream fixes podman dependency with bootc
+    #podman \
     btrfs-progs \
     e2fsprogs \
     xfsprogs \
@@ -53,20 +45,11 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx apk add -X https://packages.
     glib \
     shadow
 
-
-# Add ostree tmpfile
-COPY --from=ctx files/ostree-0-integration.conf /mnt/usr/lib/tmpfiles.d/
-COPY --from=ctx files/prepare-root.conf /mnt/usr/lib/ostree/
-
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx apk add --allow-untrusted \
     /ctx/packages/$(arch)/composefs*.apk \
     /ctx/packages/$(arch)/ostree*.apk \
+    /ctx/packages/$(arch)/bootupd*.apk \
     /ctx/packages/$(arch)/kernel*.apk
-
-RUN mkdir -p /mnt/sysroot/ostree && \
-    ostree init --repo /mnt/sysroot/ostree/repo --verbose
-
-RUN ostree commit --repo /mnt/sysroot/ostree/repo --branch latest --bootable /mnt --no-xattrs --verbose
 
 # Turn the pacstrapped rootfs into a container image.
 FROM scratch
@@ -74,16 +57,17 @@ COPY --from=builder /mnt /
 
 # Generate initramfs
 RUN ln -s /usr/lib/modules /lib/modules
-RUN --mount=type=tmpfs,dst=/var/tmp /usr/bin/dracut --no-hostonly --kver "6.13.6" --reproducible --zstd -v -f "/usr/lib/modules/6.13.6/initramfs.img"
 
 # Alter root file structure a bit for ostree
 RUN mkdir -p /sysroot/ostree /efi /boot && \
     rm -rf /boot/* /var/log /home /root /usr/local /srv && \
-    ln -s /sysroot/ostree /ostree && \
     ln -s /var/home /home && \
     ln -s /var/roothome /root && \
     ln -s /var/usrlocal /usr/local && \
     ln -s /var/srv /srv
+
+# Ostree root settings
+COPY ./manifests/composefs-rs/prepare-root.conf /usr/lib/ostree/prepare-root.conf
 
 # Necessary labels
 LABEL containers.bootc 1

--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,7 @@ build-tree:
     just build composefs
     just build ostree
     just build bootc
+    just build bootupd
 
     just build composefs-rs
     just build dracut
@@ -91,4 +92,4 @@ generate-bootable-image:
     if [ ! -e ./bootable.img ] ; then
         fallocate -l 20G bootable.img
     fi
-    just bootc install to-disk --via-loopback /data/bootable.img --filesystem ext4
+    just bootc install to-disk --composefs-native --via-loopback /data/bootable.img --filesystem ext4

--- a/manifests/composefs-rs/prepare-root.conf
+++ b/manifests/composefs-rs/prepare-root.conf
@@ -1,0 +1,4 @@
+[composefs]
+enabled = yes
+[sysroot]
+readonly = true

--- a/manifests/kernel-initramfs.yaml
+++ b/manifests/kernel-initramfs.yaml
@@ -37,7 +37,7 @@ environment:
       - util-linux
       - device-mapper
       - openssl
-      - composefs-setup-root
+      - composefs-rs-dracut
 
 pipeline:
   - runs: |


### PR DESCRIPTION
Currently fails on `generate-bootable-image` with the following error:

```sh
Running bootupctl to install bootloader
> bootupctl backend install --write-uuid --device /dev/loop1 /run/bootc/mounts/rootfs
error: boot data installation failed: installing component BIOS: No update metadata for component BIOS found
error: Installing to disk: Setting up composefs boot: Installing bootloader: Task Running bootupctl to install bootloader failed: ExitStatus(unix_wait_status(256))
error: Recipe `bootc` failed on line 88 with exit code 1
error: Recipe `generate-bootable-image` failed with exit code 1
```