### PR TITLE
fix: Add packages needed for initramfs + root passwd

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -60,5 +60,9 @@ RUN mkdir -p /boot /sysroot && \
     ln -s /var/usrlocal /usr/local && \
     ln -s /var/srv /srv
 
+# Setup a temporary root passwd (changeme) for dev purposes
+# TODO: Replace this for a more robust option when in prod
+RUN usermod -p '$6$AJv9RHlhEXO6Gpul$5fvVTZXeM0vC03xckTIjY8rdCofnkKSzvF5vEzXDKAby5p3qaOGTHDypVVxKsCE3CbZz7C3NXnbpITrEUvN/Y/' root
+
 # Necessary labels
 LABEL containers.bootc 1

--- a/manifests/kernel-initramfs.yaml
+++ b/manifests/kernel-initramfs.yaml
@@ -40,6 +40,11 @@ environment:
       - openssl
       - composefs-rs-dracut
       - util-linux-login
+      - mount
+      - umount
+      - blkid
+      - losetup
+
 
 pipeline:
   - runs: |


### PR DESCRIPTION
We turned off most of Dracut's host detection, so it depends on these packages being available in its build process to successfully generate a initramfs that switches to the real root.

Also add a temporary root "changeme" password just so we can login for dev purposes. In production we should use build-args or something more robust.